### PR TITLE
Add support for output onto loader-type entities

### DIFF
--- a/source/libs/classes/BeltFactory.lua
+++ b/source/libs/classes/BeltFactory.lua
@@ -2,7 +2,7 @@ require "libs.classes.BeltAccess"
 require "libs.classes.SplitterAccess"
 
 BeltFactory={}
-BeltFactory.supportedTypes = {"transport-belt","splitter","underground-belt"}
+BeltFactory.supportedTypes = {"transport-belt","splitter","underground-belt","loader"}
 
 BeltFactory.accessFor = function(entity,accessTarget,accessFrom)
 	if entity.type == "transport-belt" then
@@ -10,6 +10,8 @@ BeltFactory.accessFor = function(entity,accessTarget,accessFrom)
 	elseif entity.type == "splitter" then
 		return SplitterAccess(entity,accessTarget,accessFrom)
 	elseif entity.type == "underground-belt" then
+		return BeltAccess(entity,accessFrom)
+	elseif entity.type == "loader" then
 		return BeltAccess(entity,accessFrom)
 	else
 		warn("Invalid entity type: "..entity.type.." to create an access object.")


### PR DESCRIPTION
Loader transport lines work pretty much the same as underground belts, this ties them in as an entity that the sorters will output onto.  I haven't tested exhaustively but this seems to work with anything based on vanilla loaders as well as special ones like miniloaders.